### PR TITLE
fix_contract_controller

### DIFF
--- a/app/assets/javascripts/contract.js
+++ b/app/assets/javascripts/contract.js
@@ -2,7 +2,7 @@ $(document).on('turbolinks:load', function(){
   $(".confirm").click(function(){
     $(".quantity").each(function(index, element){
       let val = $(element).val();
-      if(val == "" || val == 0 ){
+      if($.isNumeric(val) == false) {
         $(element).parent().parent().remove();
       }
     })

--- a/app/controllers/contracts_controller.rb
+++ b/app/controllers/contracts_controller.rb
@@ -58,9 +58,9 @@ class ContractsController < ApplicationController
       ActionController::Parameters.new(param.to_unsafe_h).permit(:unit_price, :quantity, :product_name, :total_price, :order_id, :supplier_id, :delivery_date, :product_unit)
     end
   rescue => e
-    redirect_to action: :new   and return  
-
+    redirect_to new_contract_path, alert: "入力内容が正しくありません" and return  
     
+
   end
 
 


### PR DESCRIPTION
###WHAT
注文の際に、不正な値を全て弾き、かつエラ〜メッセージを表示できるようにした。
###WHY
半角数字以外の値でも、注文確認画面にいけるようになっていたため